### PR TITLE
	modified:   chroma/cuda/geometry_types.h

### DIFF
--- a/chroma/cuda/geometry_types.h
+++ b/chroma/cuda/geometry_types.h
@@ -39,6 +39,7 @@ struct SiPMEmpiricalProps
     float *angles;
     float **sipmEmpirical_reflect;
     float **sipmEmpirical_relativePDE;
+    float diffuseRefl;  
     unsigned int nangles;
 };
 

--- a/chroma/cuda/geometry_types.h
+++ b/chroma/cuda/geometry_types.h
@@ -38,9 +38,10 @@ struct SiPMEmpiricalProps
 {
     float *angles;
     float **sipmEmpirical_reflect;
+    float **sipmEmpirical_transmit;  // New field for transmission data
     float **sipmEmpirical_relativePDE;
     float diffuseRefl;  
-    float Absorption;
+    float FillFactor;  // Changed from Absorption to FillFactor
     unsigned int nangles;
 };
 

--- a/chroma/cuda/geometry_types.h
+++ b/chroma/cuda/geometry_types.h
@@ -40,6 +40,7 @@ struct SiPMEmpiricalProps
     float **sipmEmpirical_reflect;
     float **sipmEmpirical_relativePDE;
     float diffuseRefl;  
+    float Absorption;
     unsigned int nangles;
 };
 

--- a/chroma/cuda/photon.h
+++ b/chroma/cuda/photon.h
@@ -757,31 +757,46 @@ propagate_at_sipmEmpirical(Photon &p, State &s, curandState &rng, Surface *surfa
     float reflect_prob = reflect_prob_low + (reflect_prob_high-reflect_prob_low)*(idx-iidx);
     float relativePDE_prob = relativePDE_prob_low + (relativePDE_prob_high-relativePDE_prob_low)*(idx-iidx);
 
+    // Absorption parameter from equation 4 (= 0.27 in the ExCT paper)
+    float absorption_A = props->Absorption;
     float uniform_sample = curand_uniform(&rng);
-
+    
     // Calculate the probability thresholds for a single random number
     float p1 = props->diffuseRefl;  // Diffuse reflection threshold
-    float p2 = p1 + (1.0f - p1) * reflect_prob;  // Specular reflection threshold 
-    float p3 = p2 + (1.0f - p1) * (1.0f - reflect_prob) * relativePDE_prob;  // Detection threshold
-
+    
+    // Specular reflection is reduced by absorption parameter A
+    float effective_specular_prob = (1.0f - p1) * reflect_prob * (1.0f - absorption_A);
+    float p2 = p1 + effective_specular_prob;  // Specular reflection threshold 
+    
+    // Absorption due to A parameter
+    float absorption_from_specular = (1.0f - p1) * reflect_prob * absorption_A;
+    float p3 = p2 + absorption_from_specular;  // Absorption threshold from specular
+    // Detection threshold
+    float p4 = p3 + (1.0f - p1) * (1.0f - reflect_prob) * relativePDE_prob;
+    
     // Use one random number to determine outcome
     if (uniform_sample < p1) {
         // Diffuse reflection
         return propagate_at_diffuse_reflector(p, s, rng);
     }
     else if (uniform_sample < p2) {
-        // Specular reflection
+        // Specular reflection (those that weren't absorbed by A)
         return propagate_at_specular_reflector(p, s);
     } 
     else if (uniform_sample < p3) {
+        // Absorption due to parameter A (for photons that would have been specularly reflected)
+        p.history |= SURFACE_ABSORB;
+    }
+    else if (uniform_sample < p4) {
         // Detection
         p.history |= SURFACE_DETECT;
     } 
     else {
-        // Absorbed without signal
+        // Absorbed without signal (photons that transmitted but weren't detected)
         p.history |= SURFACE_ABSORB;
     }
-return BREAK;
+    
+    return BREAK;
 }// propagate_at_sipmEmpirical
 
 __device__ int

--- a/chroma/cuda/photon.h
+++ b/chroma/cuda/photon.h
@@ -430,8 +430,7 @@ propagate_complex(Photon &p, State &s, curandState &rng, Surface* surface, bool 
     cuFloatComplex ratio12sin = cuCmulf(cuCmulf(cuCdivf(n1, n2), cuCdivf(n1, n2)), cuCmulf(sin1, sin1));
     cuFloatComplex cos2 = cuCsqrtf(cuCsubf(make_cuFloatComplex(1.0f,0.0f), ratio12sin));
     float u = cuCrealf(cuCmulf(n2, cos2));
-    float v22 = cuCimagf(cuCmulf(n2, cos2));
-    float v2 = sqrt(v22);
+    float v = cuCimagf(cuCmulf(n2, cos2));
 
     // s polarization
     cuFloatComplex s_n1c1 = cuCmulf(n1, cos1);
@@ -782,7 +781,7 @@ propagate_at_sipmEmpirical(Photon &p, State &s, curandState &rng, Surface *surfa
         // Absorbed without signal
         p.history |= SURFACE_ABSORB;
     }
-    return BREAK;
+return BREAK;
 }// propagate_at_sipmEmpirical
 
 __device__ int

--- a/chroma/cuda/photon.h
+++ b/chroma/cuda/photon.h
@@ -759,7 +759,13 @@ propagate_at_sipmEmpirical(Photon &p, State &s, curandState &rng, Surface *surfa
     
     float uniform_sample = curand_uniform(&rng);
     if ((uniform_sample < reflect_prob)) {
-        return propagate_at_specular_reflector(p, s);
+        // Determine if reflection is diffuse or specular
+        float reflection_type = curand_uniform(&rng);
+        if (reflection_type < props->diffuseRefl) {
+            return propagate_at_diffuse_reflector(p, s, rng);
+        } else {
+            return propagate_at_specular_reflector(p, s);
+        }
     }
     else {
         // absorb

--- a/chroma/geometry.py
+++ b/chroma/geometry.py
@@ -251,10 +251,11 @@ class DichroicProps(object):
         self.dichroic_transmit = np.asarray(transmit) #[angle][point]
 
 class SiPMEmpiricalProps(object):
-    def __init__(self, angles, reflect, relativePDE):
+    def __init__(self, angles, reflect, relativePDE, diffuseRefl=0.0):
         self.angles = np.asarray(angles)
         self.sipmEmpirical_reflect = np.asarray(reflect)
         self.sipmEmpirical_relativePDE = np.asarray(relativePDE)
+        self.diffuseRefl = diffuseRefl  # Adding diffuse reflection for SiPMs, Alex
 
 class Surface(object):
     """Surface optical properties."""

--- a/chroma/geometry.py
+++ b/chroma/geometry.py
@@ -251,12 +251,12 @@ class DichroicProps(object):
         self.dichroic_transmit = np.asarray(transmit) #[angle][point]
 
 class SiPMEmpiricalProps(object):
-    def __init__(self, angles, reflect, relativePDE, diffuseRefl=0.0):
+    def __init__(self, angles, reflect, relativePDE, diffuseRefl=0.0, Absorption=0.0):
         self.angles = np.asarray(angles)
         self.sipmEmpirical_reflect = np.asarray(reflect)
         self.sipmEmpirical_relativePDE = np.asarray(relativePDE)
         self.diffuseRefl = diffuseRefl  # Adding diffuse reflection for SiPMs, Alex
-
+        self.Absorption = Absorption  # Adding absorption for SiPMs, Alex
 class Surface(object):
     """Surface optical properties."""
     def __init__(self, name='none', model=0):

--- a/chroma/geometry.py
+++ b/chroma/geometry.py
@@ -251,12 +251,14 @@ class DichroicProps(object):
         self.dichroic_transmit = np.asarray(transmit) #[angle][point]
 
 class SiPMEmpiricalProps(object):
-    def __init__(self, angles, reflect, relativePDE, diffuseRefl=0.0, Absorption=0.0):
+    def __init__(self, angles, reflect, transmit, relativePDE, diffuseRefl=0.0, FillFactor=1.0):
         self.angles = np.asarray(angles)
         self.sipmEmpirical_reflect = np.asarray(reflect)
+        self.sipmEmpirical_transmit = np.asarray(transmit)
         self.sipmEmpirical_relativePDE = np.asarray(relativePDE)
         self.diffuseRefl = diffuseRefl  # Adding diffuse reflection for SiPMs, Alex
-        self.Absorption = Absorption  # Adding absorption for SiPMs, Alex
+        # self.Absorption = Absorption  # No absorption defined for now, Alex
+        self.FillFactor = FillFactor # Fill factor for SiPMs, Alex
 class Surface(object):
     """Surface optical properties."""
     def __init__(self, name='none', model=0):

--- a/chroma/gpu/geometry.py
+++ b/chroma/gpu/geometry.py
@@ -162,6 +162,7 @@ class GPUGeometry(object):
             if surface.sipmEmpirical_props:
                 props = surface.sipmEmpirical_props
                 diffuseRefl = props.diffuseRefl
+                Absorption = props.Absorption
                 relativePDE_pointers = []
                 reflect_pointers = []
                 angles_gpu = ga.to_gpu(np.asarray(props.angles, dtype = np.float32))
@@ -181,7 +182,9 @@ class GPUGeometry(object):
                 self.surface_data.append(reflect_arr_gpu)
                 relativePDE_arr_gpu = make_gpu_struct(8 * len(relativePDE_pointers), relativePDE_pointers)
                 self.surface_data.append(relativePDE_arr_gpu)
-                sipmEmpirical_props = make_gpu_struct(simpempiricalprops_struct_size, [angles_gpu, reflect_arr_gpu, relativePDE_arr_gpu, np.float32(diffuseRefl), np.uint32(len(props.angles))])
+                sipmEmpirical_props = make_gpu_struct(simpempiricalprops_struct_size, [angles_gpu, reflect_arr_gpu, 
+                                                                                       relativePDE_arr_gpu, np.float32(diffuseRefl), 
+                                                                                       np.float32(Absorption),np.uint32(len(props.angles))])
             else:
                 sipmEmpirical_props = np.uint64(0) #NULL
 

--- a/chroma/gpu/geometry.py
+++ b/chroma/gpu/geometry.py
@@ -161,6 +161,7 @@ class GPUGeometry(object):
             
             if surface.sipmEmpirical_props:
                 props = surface.sipmEmpirical_props
+                diffuseRefl = props.diffuseRefl
                 relativePDE_pointers = []
                 reflect_pointers = []
                 angles_gpu = ga.to_gpu(np.asarray(props.angles, dtype = np.float32))
@@ -180,7 +181,7 @@ class GPUGeometry(object):
                 self.surface_data.append(reflect_arr_gpu)
                 relativePDE_arr_gpu = make_gpu_struct(8 * len(relativePDE_pointers), relativePDE_pointers)
                 self.surface_data.append(relativePDE_arr_gpu)
-                sipmEmpirical_props = make_gpu_struct(simpempiricalprops_struct_size, [angles_gpu, reflect_arr_gpu, relativePDE_arr_gpu, np.uint32(len(props.angles))])
+                sipmEmpirical_props = make_gpu_struct(simpempiricalprops_struct_size, [angles_gpu, reflect_arr_gpu, relativePDE_arr_gpu, np.float32(diffuseRefl), np.uint32(len(props.angles))])
             else:
                 sipmEmpirical_props = np.uint64(0) #NULL
 


### PR DESCRIPTION
	modified:   chroma/cuda/photon.h
	modified:   chroma/geometry.py
	modified:   chroma/gpu/geometry.py
This pull request introduces changes to support diffuse reflection for SiPMs in the `chroma` project. 

Adding diffuse reflectivity to the `propagate_at_sipmEmpirical `function, same probability logic as the one at `propagate_dielectric_metal`. chroma-simulation code will accommodate the change accordingly. Other changes include adding a new property to the `SiPMEmpiricalProps` structure, updating the initialization, and modifying GPU-related functions to accommodate the new property. 

Changes to support diffuse reflection:

* [`chroma/cuda/geometry_types.h`](diffhunk://#diff-110a4e15bca77a97bfd169de61286b8c630a771cdb8df828328c24d1c5c07893R42): Added a new `diffuseRefl` property to the `SiPMEmpiricalProps` structure.
* [`chroma/geometry.py`](diffhunk://#diff-f4fb9135528ce46151789fa547b8d3d67cbf77c9c5933cc90f45bac4592ce8a4L254-R258): Updated the `SiPMEmpiricalProps` class constructor to include the `diffuseRefl` parameter with a default value of 0.0.
* [`chroma/cuda/photon.h`](diffhunk://#diff-7d106258a6d196bd49c16e80cdd5083d9cb5307a2e506e1170765ba745ab2eb7R762-R769): Modified the `propagate_at_sipmEmpirical` function to determine if reflection is diffuse or specular based on the new `diffuseRefl` property.
* [`chroma/gpu/geometry.py`](diffhunk://#diff-ef258718864e6ea3b5043b073aa8d2ff99d069ae0431cf30715f13f219cce55eR164): Updated the `interp_material_property` function to handle the `diffuseRefl` property and include it in the GPU structure. [[1]](diffhunk://#diff-ef258718864e6ea3b5043b073aa8d2ff99d069ae0431cf30715f13f219cce55eR164) [[2]](diffhunk://#diff-ef258718864e6ea3b5043b073aa8d2ff99d069ae0431cf30715f13f219cce55eL183-R184)
	
@dgallacher1 please review.